### PR TITLE
Added functionality for JWT in requests which are locked behind authenticated middleware class

### DIFF
--- a/Controllers/UsersController.php
+++ b/Controllers/UsersController.php
@@ -1,6 +1,13 @@
 <?php
 namespace Controllers;
 
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+use Dotenv\Dotenv;
+$dotenv = Dotenv::createImmutable(ROOT_DIR);
+$dotenv->load();
+
 use Models\Users;
 use Models\Mailer;
 class UsersController extends Controller
@@ -162,9 +169,20 @@ class UsersController extends Controller
         if (!password_verify($_GET['password'], $result['password'])) {
             return $this->jsonErrorResponse("Password did not match");
         }
+        
+        $currentDateTime = date("Y-m-d H:i:s");
+        // Expirationdate on the jwtoken
+        $expirationDateTime = date("Y-m-d H:i:s", strtotime($currentDateTime . " +30 days"));
+        $key = $_ENV["JWT_KEY"];
 
-        //In the future this is the JWToken
-        $JWToken = "This is a JWToken";
-        return $this->jsonSuccessResponse($JWToken);
+        $payload = [
+        'username' => $result['username'],
+        'email' => $_GET['email'],
+        'jwt_expiration' => $expirationDateTime
+        ];
+
+        $jwt = JWT::encode($payload, $key, 'HS256');
+
+        return $this->jsonSuccessResponse($jwt);
     }
 }

--- a/Middleware/Authenticated.php
+++ b/Middleware/Authenticated.php
@@ -1,6 +1,15 @@
 <?php
-
 namespace Middleware;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\SignatureInvalidException;
+
+use Dotenv\Dotenv;
+$dotenv = Dotenv::createImmutable(ROOT_DIR);
+$dotenv->load();
 
 use Pecee\Http\Middleware\IMiddleware;
 use Pecee\Http\Request;
@@ -9,7 +18,68 @@ class Authenticated implements IMiddleware
 {
     public function handle(Request $request): void
     {
-        echo 'This user is authenticated, if not, redirect.';
-        die;
+        /*
+            IF Rene has time to change it in the app, to where the jwt response is in the header of the request
+            it needs be changed to $_SERVER['HTTP_AUTHORIZATION'] instead of get
+            since it's more secure, (value wont be logged, and much more)
+        */
+        if (!isset($_GET['jwt'])) {
+            echo json_encode(['status' => 'failed', 'response' => 'no jwt']);
+            die;
+        }
+        $jwt = $_GET['jwt'];
+        
+        try {
+                // This is to make sure that there it's no more than X seconds since the request was made,
+                // if more time than this has passed, it will fail.
+                JWT::$leeway = 30; // $leeway in seconds
+                $decoded = JWT::decode($jwt, new Key($_ENV["JWT_KEY"], 'HS256'));
+                $decoded_array = (array) $decoded;
+
+                /*
+                    The following section is to make sure the same token is not in circulation for too long.
+                    Since a new token is generated every time a user logs in, it should not become a problem,
+                    but for future use, if it needs to be possible to have a user stay logged in,
+                    there has been set an experation date, which when exceeded,
+                    forces the user to login again, or they can't make requests to in this case,
+                    any routes which make use of the Authenticated middleware.
+                */
+                $jwtIsExpired = $decoded_array['jwt_expiration'];
+                $currentDateTime = date("Y-m-d H:i:s");
+                if ($currentDateTime > $jwtIsExpired) {
+                    echo json_encode(['status' => 'failed', 'response' => 'JWToken has expired']);
+                    die;
+                }
+
+            } catch (ExpiredException $e) {
+                // Token is expired. Handle accordingly.
+                http_response_code(401);
+                echo json_encode(['error' => 'Token expired']);
+                die;
+            } catch (BeforeValidException $e) {
+                // Token is not yet valid. Handle accordingly.
+                http_response_code(401);
+                echo json_encode(['error' => 'Token not yet valid']);
+                die;
+            } catch (SignatureInvalidException $e) {
+                // Token signature is invalid, indicating possible tampering.
+                http_response_code(401);
+                echo json_encode(['error' => 'Invalid token signature']);
+                die;
+            } catch (\Throwable $e) {
+                // Catch any Throwable, including DomainException for malformed UTF-8 characters.
+                http_response_code(400);
+                echo json_encode(['error' => 'Malformed or invalid JWT']);
+                die;
+            } catch (\Exception $e) {
+                /*
+                    Catch any Exception, including DomainException for malformed UTF-8 characters.
+                    This is a last case scenario, so if there is some unforseen error with the jwToken
+                    the following will be sent back as a response to the end-user.
+                */
+                http_response_code(400);
+                echo json_encode(['error' => 'Malformed or invalid JWT']);
+                die;
+            }
     }
 }

--- a/routes.php
+++ b/routes.php
@@ -9,19 +9,22 @@
     };
 
     Route::get('/', function () {
-        return "Default route";        
+        return "This website is for litethreads api's";        
+    });
+    Route::get('/page_not_found', function () {
+        return "Page or api call not found";        
+    });
+    Route::get('/access_denied', function () {
+        return "Don't have access to that api / page";        
     });
 
     // User api's
-    Route::get('/get_user_with_id', 'UsersController@GetUserById');
-    Route::get('/users', 'UsersController@GetUsers');
     Route::get('/get_user_availability', 'UsersController@CheckUsernameEmailAvailable');
-
-    // These should be post requests, but because of the hosting provider difficulties, they are get for now.
     Route::get('/create_mail_verf','UsersController@CreateUserMailVerf');
     Route::get('/verf_mail_code','UsersController@VerfMailCode');
     Route::get('/create_user', 'UsersController@CreateUser');
     Route::get('/login_user', 'UsersController@LoginUser');
+
 
     // Group api's
     Route::get('/get_users_followed_groups','GroupsController@GetUsersFollowedGroups');
@@ -30,7 +33,7 @@
     Route::get('/follow_group','GroupsController@FollowGroup');
     Route::get('/unfollow_group','GroupsController@UnfollowGroup');
     
-    // Post api's
+    // post api calls
     Route::get('/create_user_post','PostsController@CreateUserPost');
     Route::get('/create_group_post','PostsController@CreateUserGroupPost');
     Route::get('/vote_on_post','PostsController@VoteOnPost');
@@ -42,37 +45,28 @@
     Route::get('/get_user_followed_users_posts','PostsController@GetPostsFromFollowedUsers');
     Route::get('/get_user_followed_users_and_groups_posts','PostsController@GetPostsFromFollowedGroupsAndUsers');
     
-    Route::get('/sendmail', 'MailsController@SendMail');
-
-    //For testing purposes
-    Route::get('/api/get_hello', function () {
-            $people["1"] = array("Peter"=>35, "Ben"=>37, "Joe"=>43);
-            $people["2"] = array("David"=>35, "Carl"=>37, "Doesen"=>43);
-            return json_encode($age);
-            //view('login');
-        });
-
-    // This is how the setup looks, when you need to stop people from accessing a route, unless they are stopped by the authenticating middleware.
+    // These routes are only available if a valid JWToken is sent with the request (For now as a get(provider issues))
     Route::group(['middleware' => Authenticated::class], function () {
-        Route::get('/check', function () {
-            // return 'Hello world'. $_SESSION['user_role'];
-            view('login');
-        });
+        // Most of these requests should be post requests, but because of hosting provider difficulties
+        // they have been set and updated to be get requests
+        
     });
         
 
     // This is error handling routing, and will be looked at later. This is only and example.
-    // Route::error(function(Request $request, \Exception $exception) {
-    //     switch($exception->getCode()) {
-    //         // Page not found
-    //         case 404:
-    //             response()->redirect('/');
-    //         // Forbidden
-    //         case 403:
-    //             response()->redirect('/');
-    //     }
+    Route::error(function(Request $request, \Exception $exception) {
+        switch($exception->getCode()) {
+            // Page not found
+            case 404:
+                response()->redirect('/page_not_found');
+            // Forbidden
+            // This only happens if a jwtoken is sent with, but it doesn't have the correct values, 
+            // which it needs for the Route::Group that it's in.
+            case 403:
+                response()->redirect('/access_denied');
+        }
         
-    // });
+    });
 
 
 


### PR DESCRIPTION
Currently the post/group routes are outside of the group, but that is only for testing purposes, will change once we know how we need to retrieve the JWT from the client/user

Also added retirect functionality for both page not found and access denied.