### PR TITLE
Changed the way we validate curr user. now done from jwt values

### DIFF
--- a/Controllers/UsersController.php
+++ b/Controllers/UsersController.php
@@ -201,14 +201,10 @@ class UsersController extends Controller
 
     // The following is in regards to following users unfollowing etc.
     public function FollowUnfollowUser() {
-        $requiredValues = ['username', 'follow_username'];
+        $requiredValues = ['follow_username'];
         $missingValues = $this->checkRequiredValues($requiredValues);
         if ($missingValues)
             return $this->jsonErrorResponse($missingValues);
-
-        $validUser = $this->users->getUserByUsername($_GET['username']);
-        if (empty($validUser))
-            $error['invalid_value'][] = "User";
 
         $validFollowUser = $this->users->getUserByUsername($_GET['follow_username']);
         if (empty($validFollowUser))
@@ -217,17 +213,17 @@ class UsersController extends Controller
         if (!empty($error['invalid_value']))
             return $this->jsonErrorResponse($error);
 
-        $alreadyFollow = $this->users->userAlreadyFollowed($validUser['id'], $validFollowUser['id']);
+        $alreadyFollow = $this->users->userAlreadyFollowed($this->jwtInfo['user_id'], $validFollowUser['id']);
         if (!empty($alreadyFollow)) {
-            $unfollowed = $this->users->unfollowUser($validUser['id'], $validFollowUser['id']);
+            $unfollowed = $this->users->unfollowUser($this->jwtInfo['user_id'], $validFollowUser['id']);
             if ($unfollowed) {
                 return $this->jsonSuccessResponse("User was unfollowed");
             } else {
-                return $this->jsonErrorResponse("User is already follow, but could not be unfollowed)");
+                return $this->jsonErrorResponse("User is already followed, but could not be unfollowed)");
             }
         }
 
-        $followUser = $this->users->followUser($validUser['id'], $validFollowUser['id']);
+        $followUser = $this->users->followUser($this->jwtInfo['user_id'], $validFollowUser['id']);
         if (!$followUser)
             return $this->jsonErrorResponse("User could not be followed");
 
@@ -235,20 +231,7 @@ class UsersController extends Controller
     }
 
     public function GetFollowedUsers () {
-        $requiredValues = ['username'];
-        $missingValues = $this->checkRequiredValues($requiredValues);
-        if ($missingValues)
-            return $this->jsonErrorResponse($missingValues);
-
-
-        $validUser = $this->users->getUserByUsername($_GET['username']);
-        if (empty($validUser))
-            $error['invalid_value'] = "User";
-
-        if (!empty($error['invalid_value']))
-        return $this->jsonErrorResponse($error);
-
-        $followedUsers = $this->users->getFollowedUsers($validUser['id']);
+        $followedUsers = $this->users->getFollowedUsers($this->jwtInfo['user_id']);
         if (empty($followedUsers))
             return $this->jsonSuccessResponse("No followed users");
 

--- a/Models/Posts.php
+++ b/Models/Posts.php
@@ -160,15 +160,22 @@ class Posts extends DB {
             FROM
                 posts p
             INNER JOIN
-                followed_users fu ON p.user_id = fu.followed_user_id
-            INNER JOIN
-                users u ON u.id = fu.followed_user_id
+                users u ON u.id = p.user_id
             LEFT JOIN
                 VoteCounts vc ON p.id = vc.post_id
             LEFT JOIN
                 users_posts_votes upv ON p.id = upv.post_id AND upv.user_id = ?
             WHERE
-                fu.user_id = ? AND p.is_archived = false", [$user_id, $user_id]);
+                p.is_archived = false
+                AND p.group_id IS NULL
+                AND p.user_id IN (
+                    SELECT id
+                    FROM users u
+                    WHERE u.id IN (
+                        SELECT fu.followed_user_id
+                        FROM followed_users fu
+                        WHERE fu.user_id = ?
+                    ))", [$user_id, $user_id]);
 
         return $posts; 
     }
@@ -288,9 +295,7 @@ class Posts extends DB {
             FROM
                 posts p
             INNER JOIN
-                followed_users fu ON p.user_id = fu.followed_user_id
-            INNER JOIN
-                users u ON u.id = fu.followed_user_id
+                users u ON u.id = p.user_id
             LEFT JOIN
                 VoteCounts vc ON p.id = vc.post_id
             LEFT JOIN
@@ -326,9 +331,7 @@ class Posts extends DB {
                 FROM
                     posts p
                 INNER JOIN
-                    followed_users fu ON p.user_id = fu.followed_user_id
-                INNER JOIN
-                    users u ON u.id = fu.followed_user_id
+                    users u ON u.id = p.user_id
                 LEFT JOIN
                     `groups` g ON g.id = p.group_id
                 LEFT JOIN


### PR DESCRIPTION
Also fixed a bug with 3 queries, getPostsFromFollowedUsers, getPostsFromSpecificUser and getPostsFromSpecificUserWall

The majority of what was done here, was change all the places where we get a username in the request to instead just use the user values from the JWT. By doing this, we could delete all the checks where we checked if it's a valid user or not,  because if it's not a valid user, it doesn't have a jwt, and therefore can't call the request.