### PR TITLE
Updated the queries so they return the correct values

### DIFF
--- a/Models/Posts.php
+++ b/Models/Posts.php
@@ -390,7 +390,9 @@ class Posts extends DB {
                         SELECT category_id
                         FROM users_followed_categories ufc
                         WHERE ufc.user_id = ?
-                    ))",[$user_id, $user_id]);
+                    )
+                )
+                AND p.group_id NOT IN (SELECT group_id FROM followed_groups WHERE user_id = ?)",[$user_id, $user_id, $user_id]);
 
         return $posts; 
     }


### PR DESCRIPTION
Updated the queries so they return the correct values.

groupsFromFollowedCategories no longer returns groups which the user already follows

PostsFromGroupsWithUserFollowedCategories no longer returns posts from groups which the user follows.
